### PR TITLE
feat(applicator): spread field on applyMiddlewareToField

### DIFF
--- a/src/applicator.ts
+++ b/src/applicator.ts
@@ -45,25 +45,34 @@ function applyMiddlewareToField<TSource, TContext, TArgs>(
 ): IResolverOptions {
   if (isMiddlewareWithFragment(middleware) && field.resolve) {
     return {
+      ...field,
       fragment: middleware.fragment,
       fragments: middleware.fragments,
       resolve: wrapResolverInMiddleware(field.resolve, middleware.resolve),
     }
   } else if (isMiddlewareWithFragment(middleware) && field.subscribe) {
     return {
+      ...field,
       fragment: middleware.fragment,
       fragments: middleware.fragments,
       subscribe: wrapResolverInMiddleware(field.subscribe, middleware.resolve),
     }
   } else if (isMiddlewareResolver(middleware) && field.resolve) {
-    return { resolve: wrapResolverInMiddleware(field.resolve, middleware) }
+    return {
+      ...field,
+      resolve: wrapResolverInMiddleware(field.resolve, middleware),
+    }
   } else if (isMiddlewareResolver(middleware) && field.subscribe) {
-    return { subscribe: wrapResolverInMiddleware(field.subscribe, middleware) }
+    return {
+      ...field,
+      subscribe: wrapResolverInMiddleware(field.subscribe, middleware),
+    }
   } else if (
     isMiddlewareWithFragment(middleware) &&
     !options.onlyDeclaredResolvers
   ) {
     return {
+      ...field,
       fragment: middleware.fragment,
       fragments: middleware.fragments,
       resolve: wrapResolverInMiddleware(
@@ -76,10 +85,11 @@ function applyMiddlewareToField<TSource, TContext, TArgs>(
     !options.onlyDeclaredResolvers
   ) {
     return {
+      ...field,
       resolve: wrapResolverInMiddleware(defaultFieldResolver, middleware),
     }
   } else {
-    return { resolve: defaultFieldResolver }
+    return { ...field, resolve: defaultFieldResolver }
   }
 }
 

--- a/src/test/extra-properties.test.ts
+++ b/src/test/extra-properties.test.ts
@@ -1,0 +1,157 @@
+import test from 'ava'
+import { makeExecutableSchema } from 'graphql-tools'
+import { graphql } from 'graphql'
+
+import { applyMiddleware } from '../'
+
+// Setup ---------------------------------------------------------------------
+
+const typeDefs = `
+  type Query {
+    withObjectTypeConfig: String!
+  }
+
+  type Mutation {
+    withObjectTypeConfig: String!
+  }
+
+  schema {
+    query: Query,
+    mutation: Mutation,
+  }
+`
+
+const resolvers = {
+  Query: {
+    withObjectTypeConfig: {
+      extraProperties: 'extra properties are passed down',
+      resolve: () => 'withObjectTypeConfig',
+    },
+  },
+  Mutation: {
+    withObjectTypeConfig: {
+      extraProperties: 'extra properties are passed down',
+      resolve: () => 'withObjectTypeConfig',
+    },
+  },
+}
+
+const getSchema = () => makeExecutableSchema({ typeDefs, resolvers })
+
+// Middleware ----------------------------------------------------------------
+
+// Field Middleware
+
+const fieldMiddleware = {
+  Query: {
+    withObjectTypeConfig: async (resolve, parent, args, context, info) => {
+      return (
+        info.schema.getQueryType().getFields()[info.fieldName]
+          .extraProperties || 'fail'
+      )
+    },
+  },
+  Mutation: {
+    withObjectTypeConfig: async (resolve, parent, args, context, info) => {
+      return (
+        info.schema.getMutationType().getFields()[info.fieldName]
+          .extraProperties || 'fail'
+      )
+    },
+  },
+}
+
+// Type Middleware
+
+const typeMiddlewareBefore = {
+  Query: async (resolve, parent, args, context, info) => {
+    return (
+      info.schema.getQueryType().getFields()[info.fieldName].extraProperties ||
+      'fail'
+    )
+  },
+  Mutation: async (resolve, parent, args, context, info) => {
+    return (
+      info.schema.getMutationType().getFields()[info.fieldName]
+        .extraProperties || 'fail'
+    )
+  },
+}
+
+// Test ----------------------------------------------------------------------
+
+// Field
+
+test('Additional properties are passed down properly on field middleware - Query', async t => {
+  const schema = getSchema()
+  const schemaWithMiddleware = applyMiddleware(schema, fieldMiddleware)
+
+  const query = `
+    query {
+      withObjectTypeConfig
+    }
+  `
+  const res = await graphql(schemaWithMiddleware, query)
+
+  t.deepEqual(res, {
+    data: {
+      withObjectTypeConfig: 'extra properties are passed down',
+    },
+  })
+})
+
+test('Additional properties are passed down properly on field middleware - Mutation', async t => {
+  const schema = getSchema()
+  const schemaWithMiddleware = applyMiddleware(schema, fieldMiddleware)
+
+  const query = `
+    mutation {
+      withObjectTypeConfig
+    }
+  `
+  const res = await graphql(schemaWithMiddleware, query)
+
+  t.deepEqual(res, {
+    data: {
+      withObjectTypeConfig: 'extra properties are passed down',
+    },
+  })
+})
+
+// Type
+
+test('Additional properties are passed down properly on type middleware - Query', async t => {
+  const schema = getSchema()
+  const schemaWithMiddleware = applyMiddleware(schema, typeMiddlewareBefore)
+
+  const query = `
+    query {
+      withObjectTypeConfig
+    }
+  `
+  const res = await graphql(schemaWithMiddleware, query)
+
+  t.deepEqual(res, {
+    data: {
+      withObjectTypeConfig: 'extra properties are passed down',
+    },
+  })
+})
+
+test('Additional properties are passed down properly on type middleware - Mutation', async t => {
+  const schema = getSchema()
+  const schemaWithMiddleware = applyMiddleware(schema, typeMiddlewareBefore)
+
+  const query = `
+    mutation {
+      withObjectTypeConfig
+    }
+  `
+  const res = await graphql(schemaWithMiddleware, query)
+
+  t.deepEqual(res, {
+    data: {
+      withObjectTypeConfig: 'extra properties are passed down',
+    },
+  })
+})

--- a/src/test/index.test.ts
+++ b/src/test/index.test.ts
@@ -26,7 +26,6 @@ const typeDefs = `
     afterNothing: String!
     null: String
     nested: Nothing!
-    withObjectTypeConfig: String!
   }
   
   type Subscription {
@@ -65,10 +64,6 @@ const resolvers = {
     afterNothing: () => 'after',
     null: () => null,
     nested: () => ({}),
-    withObjectTypeConfig: {
-      extraProperties: 'extra properties are passed down',
-      resolve: () => 'withObjectTypeConfig'
-    }
   },
   Subscription: {
     sub: {
@@ -117,9 +112,6 @@ const fieldMiddleware = {
     after: async (resolve, parent, args, context, info) => {
       const res = resolve()
       return 'changed'
-    },
-    withObjectTypeConfig: async (resolve, parent, args, context, info) => {
-      return info.schema.getMutationType().getFields()[info.fieldName].extraProperties || 'fail'
     },
   },
   Subscription: {
@@ -222,7 +214,6 @@ test('Field middleware - Mutation', async t => {
       afterNothing
       null
       nested { nothing }
-      withObjectTypeConfig
     }
   `
   const res = await graphql(schemaWithMiddleware, query)
@@ -235,7 +226,6 @@ test('Field middleware - Mutation', async t => {
       afterNothing: 'after',
       null: null,
       nested: { nothing: 'nothing' },
-      withObjectTypeConfig: 'extra properties are passed down',
     },
   })
 })

--- a/src/test/index.test.ts
+++ b/src/test/index.test.ts
@@ -26,6 +26,7 @@ const typeDefs = `
     afterNothing: String!
     null: String
     nested: Nothing!
+    withObjectTypeConfig: String!
   }
   
   type Subscription {
@@ -64,6 +65,10 @@ const resolvers = {
     afterNothing: () => 'after',
     null: () => null,
     nested: () => ({}),
+    withObjectTypeConfig: {
+      extraProperties: 'extra properties are passed down',
+      resolve: () => 'withObjectTypeConfig'
+    }
   },
   Subscription: {
     sub: {
@@ -112,6 +117,9 @@ const fieldMiddleware = {
     after: async (resolve, parent, args, context, info) => {
       const res = resolve()
       return 'changed'
+    },
+    withObjectTypeConfig: async (resolve, parent, args, context, info) => {
+      return info.schema.getMutationType().getFields()[info.fieldName].extraProperties || 'fail'
     },
   },
   Subscription: {
@@ -214,6 +222,7 @@ test('Field middleware - Mutation', async t => {
       afterNothing
       null
       nested { nothing }
+      withObjectTypeConfig
     }
   `
   const res = await graphql(schemaWithMiddleware, query)
@@ -226,6 +235,7 @@ test('Field middleware - Mutation', async t => {
       afterNothing: 'after',
       null: null,
       nested: { nothing: 'nothing' },
+      withObjectTypeConfig: 'extra properties are passed down',
     },
   })
 })

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,5 @@
 import {
+  GraphQLField,
   GraphQLResolveInfo,
   GraphQLSchema,
   GraphQLTypeResolver,
@@ -101,7 +102,8 @@ export interface IResolverObject<TSource = any, TContext = any> {
     | IResolverOptions<TSource, TContext>
 }
 
-export interface IResolverOptions<TSource = any, TContext = any> {
+export interface IResolverOptions<TSource = any, TContext = any>
+  extends GraphQLField<any, any, any> {
   fragment?: string
   fragments?: string[]
   resolve?: IFieldResolver<TSource, TContext>


### PR DESCRIPTION
This allows for some metadata declared directly in the type/resolvers definition, to be available on the middleware.

Closes https://github.com/prisma/graphql-middleware/issues/25