### PR TITLE
Update README CircleCI badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # graphql-middleware
 
-[![CircleCI](https://circleci.com/gh/prismagraphql/graphql-middleware.svg?style=shield)](https://circleci.com/gh/prismagraphql/graphql-middleware)
+[![CircleCI](https://circleci.com/gh/prisma/graphql-middleware.svg?style=shield)](https://circleci.com/gh/prisma/graphql-middleware)
 [![npm version](https://badge.fury.io/js/graphql-middleware.svg)](https://badge.fury.io/js/graphql-middleware)
 
 All in one solution to manage middleware in your GraphQL projects.


### PR DESCRIPTION
A little update for the CircleCI badge link which is broken since `prismagraphql` move to `prisma`