### PR TITLE
chore(package): update repository links

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,13 +42,13 @@
   "release": {
     "branch": "master"
   },
-  "homepage": "https://github.com/graphcool/graphql-middleware",
+  "homepage": "https://github.com/prisma/graphql-middleware",
   "repository": {
     "type": "git",
-    "url": "https://github.com/graphcool/graphql-middleware.git"
+    "url": "https://github.com/prisma/graphql-middleware.git"
   },
   "bugs": {
-    "url": "https://github.com/graphcool/graphql-middleware/issues"
+    "url": "https://github.com/prisma/graphql-middleware/issues"
   },
   "keywords": [
     "graphql",


### PR DESCRIPTION
I'm hoping that this update will fix the build failures in master:

```json
{
   "message":"Validation Failed",
   "errors":[
      {
         "message":"The listed users and repositories cannot be searched either because the resources do not exist or you do not have permission to view them.",
         "resource":"Search",
         "field":"q",
         "code":"invalid"
      }
   ],
   "documentation_url":"https://developer.github.com/v3/search/"
}
```